### PR TITLE
Access token과 Refresh token의 개발과 배포에서 유효기간 설정 및 안내

### DIFF
--- a/src/main/java/com/solucitation/midpoint_backend/global/auth/JwtTokenProvider.java
+++ b/src/main/java/com/solucitation/midpoint_backend/global/auth/JwtTokenProvider.java
@@ -34,7 +34,7 @@ public class JwtTokenProvider {
     private String secretKey;
     private Key key;
 
-    private long accessExpirationTime = 1000 * 60; // 1분
+    private long accessExpirationTime = 1000 * 60 * 60 * 24; // 1일
     private long refreshExpirationTime = 1000 * 60 * 60 * 24 * 7; // 7일
 
     @Autowired


### PR DESCRIPTION
### 📜 작업내용
- Access token과 Refresh token의 유효기간 설정 및 안내

### 🔑 주요 변경사항
- 개발 설정

```
Access token 유효기간: 1일
Refresh token 유효기간: 7일
```

빈번한 토큰 갱신은 개발하는데 불편함이 있을 것 같아서, 개발 환경에서는 Access token의 유효기간을 1일, Refresh token의 유효기간을 7일로 설정하였습니다. 

- 배포 설정(확정x)

```
Access token 유효기간: 30분
Refresh token 유효기간: 14일
```
실제 배포 환경에서는 보안을 강화하기 위해 Access token의 유효기간을 30분, Refresh token의 유효기간을 14일로 설정할 예정입니다. 

### 🗨️ 리뷰 요구사항
개발시에 개발의 편리성을 위해 토큰 유효기간을 더 줄이거나 늘리고 싶다면

JwtTokenProvider에서 다음 코드를 수정해서 테스트해보시고, pr 날리기 전(main에 합쳐지기 전)에만 다시 `Access token 유효기간: 1일, Refresh token 유효기간: 7일` 로 변경하시면 됩니다-! 

<img width="446" alt="image" src="https://github.com/Solucitation/midpoint-backend/assets/124848492/5dd81933-c349-4fb0-8b19-f2070e350aee">
